### PR TITLE
driver: mx_dma: Sync CXL memory id to cdev creation

### DIFF
--- a/cxl_5.15/pci.c
+++ b/cxl_5.15/pci.c
@@ -1477,7 +1477,7 @@ static int cxl_mem_create_range_info(struct cxl_mem *cxlm)
 	return 0;
 }
 
-extern int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id);
+extern int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id, int cxl_memdev_id);
 extern void mxdma_driver_remove(struct pci_dev *pdev);
 
 static int cxl_mem_probe(struct pci_dev *pdev, const struct pci_device_id *id)
@@ -1521,7 +1521,7 @@ static int cxl_mem_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (range_len(&cxlm->pmem_range) && IS_ENABLED(CONFIG_CXL_PMEM))
 		rc = devm_cxl_add_nvdimm(&pdev->dev, cxlmd);
 
-	mxdma_driver_probe(pdev, id);
+	mxdma_driver_probe(pdev, id, cxlmd->id);
 
 	return rc;
 }

--- a/cxl_6.10/pci.c
+++ b/cxl_6.10/pci.c
@@ -786,7 +786,7 @@ static int cxl_event_config(struct pci_host_bridge *host_bridge,
 	return 0;
 }
 
-extern int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id);
+extern int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id, int cxl_memdev_id);
 extern void mxdma_driver_remove(struct pci_dev *pdev);
 
 static int cxl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
@@ -926,7 +926,7 @@ static int cxl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	pci_save_state(pdev);
 
-	mxdma_driver_probe(pdev, id);
+	mxdma_driver_probe(pdev, id, cxlmd->id);
 
 	return rc;
 }

--- a/mx_dma.h
+++ b/mx_dma.h
@@ -198,7 +198,7 @@ struct mx_pci_dev {
 
 extern struct file_operations *mxdma_fops_array[];
 
-int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id);
+int mxdma_driver_probe(struct pci_dev *pdev, const struct pci_device_id *id, int cxl_memdev_id);
 void mxdma_driver_remove(struct pci_dev *pdev);
 
 int transfer_id_alloc(void *ptr);


### PR DESCRIPTION
Fix invalid CXL region mapping in multi-device environments by synchronizing the CXL memory ID during the driver probing phase. This ensures proper initialization and avoids conflicts when managing multiple devices.