### PR TITLE
makefile: Support cross compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 PWD := $(shell pwd)
-BUILDSYSTEM_DIR := /lib/modules/$(shell uname -r)/build
-KERNEL_VERSION := $(shell uname -r | cut -d '.' -f 1,2)
+
+BUILDSYSTEM_DIR ?= /lib/modules/$(shell uname -r)/build
+CXL_DIR ?= cxl_6.10
+
+INSTALL_MOD_PATH ?=
+INSTALL_MOD_PATH_ARG := $(if $(strip $(INSTALL_MOD_PATH)),INSTALL_MOD_PATH="$(INSTALL_MOD_PATH)",)
 
 ifneq ($(KERNELRELEASE),)
-ifneq ($(DEBUG),)
-	EXTRA_CFLAGS += -DCONFIG_DEBUG_DMA
-endif
 	obj-m += mx_dma.o
 	mx_dma-objs := init.o fops.o helper.o transfer.o queue_handler.o
-	obj-m += cxl_$(KERNEL_VERSION)/
+	obj-m += $(CXL_DIR)/
 else
 all:
+	@echo INSTALL_MOD_PATH=$(INSTALL_MOD_PATH)
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules
 install: all
-	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules_install
-	depmod -a
+	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules_install $(INSTALL_MOD_PATH_ARG) DEPMOD=/bin/true
 clean:
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) clean
 	@/bin/rm -f *.ko modules.order *.mod.c *.o *.o.ur-safe .*.o.cmd

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-#
+
 make clean
-make install -j`nproc`
+make install -j$(nproc)
+depmod -a
 
 kernel_version=$(uname -r)
 mx_dma_path=$(find /lib/modules/${kernel_version}/ -type f -name "mx_dma.ko" 2>/dev/null)
@@ -16,5 +17,4 @@ fi
 
 sed -i '/cxl_/d' /etc/modules
 sed -i '/mx_dma/d' /etc/modules
-find "$mx_dma_dir" -type f -name "*.ko" >> /etc/modules
-
+find "$mx_dma_dir" -type f -name "*.ko" >>/etc/modules


### PR DESCRIPTION
### 수정 사항
- module(.ko)을 수행할 환경 밖에서 cross compile할 수 있도록 Makefile 수정
- BUILDSYSTEM_DIR, Kernel version, Install path를 지정할 수 있도록 수정