### PR TITLE
driver: mx_dma: Modify to use dma_pool for prp

### DIFF
--- a/init.c
+++ b/init.c
@@ -299,6 +299,8 @@ static void destroy_mx_pdev(struct pci_dev *pdev)
 	if (!mx_pdev)
 		return;
 
+	dma_pool_destroy(mx_pdev->page_pool);
+
 	mx_engine_exit(&mx_pdev->engine);
 
 	for (type = 0; type < NUM_OF_MXDMA_TYPE; type++)
@@ -368,6 +370,8 @@ static int create_mx_pdev(struct pci_dev *pdev, int cxl_memdev_id)
 		pr_err("Failed to mx_engine_init (err=%d)\n", ret);
 		goto out_fail;
 	}
+
+	mx_pdev->page_pool = dma_pool_create("mxdma_page_pool", &pdev->dev, SINGLE_DMA_SIZE, SINGLE_DMA_SIZE, 0);
 
 	mxdma_device_online(pdev);
 

--- a/mx_dma.h
+++ b/mx_dma.h
@@ -204,6 +204,8 @@ struct mx_pci_dev {
 
 	int num_of_cdev;
 	struct mx_char_dev mx_cdev[NUM_OF_MXDMA_TYPE];
+
+	struct dma_pool *page_pool;
 };
 
 extern struct file_operations *mxdma_fops_array[];

--- a/transfer.c
+++ b/transfer.c
@@ -12,11 +12,12 @@ module_param(parallel_count, int, 0644);
 /******************************************************************************/
 static void desc_list_free(struct device *dev, struct mx_transfer *transfer)
 {
+	struct mx_pci_dev *mx_pdev = dev_get_drvdata(dev);
 	int i;
 
 	for (i = 0; i < transfer->desc_list_cnt; i++) {
 		if (transfer->desc_list_va[i])
-			dma_free_coherent(dev, SINGLE_DMA_SIZE, transfer->desc_list_va[i], transfer->desc_list_ba[i]);
+			dma_pool_free(mx_pdev->page_pool, transfer->desc_list_va[i], transfer->desc_list_ba[i]);
 	}
 
 	if (transfer->desc_list_va)
@@ -27,6 +28,7 @@ static void desc_list_free(struct device *dev, struct mx_transfer *transfer)
 
 static int desc_list_alloc(struct device *dev, struct mx_transfer *transfer, int list_cnt)
 {
+	struct mx_pci_dev *mx_pdev = dev_get_drvdata(dev);
 	int i;
 
 	transfer->desc_list_cnt = list_cnt;
@@ -37,7 +39,7 @@ static int desc_list_alloc(struct device *dev, struct mx_transfer *transfer, int
 		void *cpu_addr;
 		dma_addr_t bus_addr;
 
-		cpu_addr = dma_alloc_coherent(dev, SINGLE_DMA_SIZE, &bus_addr, GFP_KERNEL);
+		cpu_addr = dma_pool_alloc(mx_pdev->page_pool, GFP_ATOMIC, &bus_addr);
 		if (!cpu_addr)
 			goto fail;
 


### PR DESCRIPTION
PRP(Data descript list)를 할당하기 위해 dma_alloc_coherent를 사용하고 있었는데,
고정된 크기를 반복 할당하기 때문에 dma_pool을 사용하는 것이 더 효율적이어서 변경.
1GB transfer를 기준으로 PRP를 할당하는 시간이 1/10로 감소