### PR TITLE
fix(mx_dma): prevent soft lockup in submit handler when HW queue is full

### DIFF
--- a/core_common.c
+++ b/core_common.c
@@ -125,12 +125,14 @@ int mx_submit_handler(void *arg)
 	const struct mx_queue_ops *ops = q->ops;
 	struct mx_transfer *transfer, *tmp;
 	unsigned long flags;
+	bool pushed_any;
 
 	while (!kthread_should_stop()) {
 		__swait_event_interruptible_timeout(q->sq_wait,
 				!list_empty(&q->sq_list),
 				POLLING_INTERVAL_MSEC);
 
+		pushed_any = false;
 		spin_lock_irqsave(&q->sq_lock, flags);
 		list_for_each_entry_safe(transfer, tmp, &q->sq_list, entry) {
 			if (!ops->is_pushable(q))
@@ -138,6 +140,7 @@ int mx_submit_handler(void *arg)
 
 			ops->push_command(q, transfer->command);
 			list_del_init(&transfer->entry);
+			pushed_any = true;
 
 			if (transfer->no_completion) {
 				/*
@@ -156,6 +159,15 @@ int mx_submit_handler(void *arg)
 
 		if (ops->post_submit)
 			ops->post_submit(q);
+
+		/*
+		 * If the HW queue was full and no commands were pushed,
+		 * sleep to avoid busy-looping (the swait above does not
+		 * sleep when sq_list is non-empty).
+		 */
+		if (!pushed_any)
+			schedule_timeout_interruptible(
+					msecs_to_jiffies(POLLING_INTERVAL_MSEC));
 	}
 
 	return 0;


### PR DESCRIPTION
## 📌 PR 요약
- HW 큐가 full일 때 submit handler가 busy-loop하여 soft lockup이 발생하는 문제 수정

## 📝 상세 내용
- `mx_submit_handler`에서 `is_pushable()`이 false를 리턴하면 swait 조건(`!list_empty`)이 이미 true이므로 sleep 없이 tight loop 발생
- push된 커맨드가 없을 때 `schedule_timeout_interruptible(4ms)`로 CPU를 양보하도록 수정
- 실제 환경에서 CPU#30이 183초간 stuck되어 migration thread 및 userspace 프로세스까지 연쇄 블록된 사례 기반

## 📦 Release Note (자동 생성용 / 영문 작성)
### NEW
-
### CHANGED
-
### FIXED
-
### IMPORTANT NOTES
-