### PR TITLE
fix(core): prevent busy-loop in complete handler when HW stalls

### DIFF
--- a/core_common.c
+++ b/core_common.c
@@ -183,12 +183,14 @@ int mx_complete_handler(void *arg)
 	while (!kthread_should_stop()) {
 		bool zombie_only = (atomic_read(&q->wait_count) > 0 &&
 				    atomic_read(&q->zombie_wait_count) == atomic_read(&q->wait_count));
+		bool popped_any = false;
 
 		__swait_event_interruptible_timeout(q->cq_wait,
 			atomic_read(&q->wait_count) - atomic_read(&q->zombie_wait_count) > 0,
 			zombie_only ? ZOMBIE_POLL_INTERVAL_MSEC : POLLING_INTERVAL_MSEC);
 
 		while (ops->is_popable(q)) {
+			popped_any = true;
 			ops->pop_completion(q, &info);
 
 			transfer = find_transfer_by_id(info.id);
@@ -217,6 +219,15 @@ int mx_complete_handler(void *arg)
 
 		if (ops->post_complete)
 			ops->post_complete(q);
+
+		/*
+		 * If completions were expected but none arrived, sleep to
+		 * avoid busy-looping (the swait above does not sleep when
+		 * its condition is already true).
+		 */
+		if (!popped_any)
+			schedule_timeout_interruptible(
+					msecs_to_jiffies(POLLING_INTERVAL_MSEC));
 	}
 
 	return 0;


### PR DESCRIPTION
## 📌 PR 요약
- device가 completion을 생성하지 않을 때 complete handler에서 발생하는 busy-loop을 방지

## 📝 상세 내용
- `wait_count > 0`이지만 `is_popable`이 false인 경우, swait 조건이 이미 true라 sleep 없이 루프가 반복되는 문제 수정
- submit handler의 `!pushed_any` 패턴과 동일하게 `!popped_any` sleep guard 추가
- device 장애 시 soft lockup(~20초 watchdog) 발생 가능성 제거

## 🔗 관련 이슈(선택)
-

## 🌿 관련 PR(선택)
-

## 🌿 관련 Branch(선택)
-

## 📦 Release Note (자동 생성용 / 영문 작성)
### NEW
-
### CHANGED
-
### FIXED
-
### IMPORTANT NOTES
-