### PR TITLE
driver: mx_dma: remove dkms.conf from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,3 @@
 modules.order
 Module.symvers
 Mkfile.old
-dkms.conf


### PR DESCRIPTION
Since mxdriver supports dkms, dkms.conf is required to install driver.